### PR TITLE
Fixes RT#90658

### DIFF
--- a/lib/Graphics/Primitive/Aligned.pm
+++ b/lib/Graphics/Primitive/Aligned.pm
@@ -3,8 +3,8 @@ use Moose::Role;
 
 use Moose::Util::TypeConstraints;
 
-enum 'Graphics::Primitive::Alignment::Horizontals' => qw(center left right);
-enum 'Graphics::Primitive::Alignment::Verticals' => qw(bottom center top);
+enum 'Graphics::Primitive::Alignment::Horizontals' => [qw(center left right)];
+enum 'Graphics::Primitive::Alignment::Verticals' => [qw(bottom center top)];
 
 has 'horizontal_alignment' => (
     is => 'rw',

--- a/lib/Graphics/Primitive/Brush.pm
+++ b/lib/Graphics/Primitive/Brush.pm
@@ -6,8 +6,8 @@ use MooseX::Storage;
 with 'MooseX::Clone';
 with Storage (format => 'JSON', io => 'File');
 
-enum 'LineCap' => qw(butt round square);
-enum 'LineJoin' => qw(miter round bevel);
+enum 'LineCap' => [qw(butt round square)];
+enum 'LineJoin' => [qw(miter round bevel)];
 
 has 'color' => ( is => 'rw', isa => 'Graphics::Color', traits => [qw(Clone)] );
 has 'dash_pattern' => ( is => 'rw', isa => 'ArrayRef' );

--- a/lib/Graphics/Primitive/Font.pm
+++ b/lib/Graphics/Primitive/Font.pm
@@ -6,27 +6,27 @@ use Moose::Util::TypeConstraints;
 with 'MooseX::Clone';
 with Storage (format => 'JSON', io => 'File');
 
-enum 'Graphics::Primitive::Font::AntialiasModes' => (
+enum 'Graphics::Primitive::Font::AntialiasModes' => [
     qw(default none gray subpixel)
-);
-enum 'Graphics::Primitive::Font::HintMetrics' => (
+];
+enum 'Graphics::Primitive::Font::HintMetrics' => [
     'default', 'off', 'on'
-);
-enum 'Graphics::Primitive::Font::HintStyles' => (
+];
+enum 'Graphics::Primitive::Font::HintStyles' => [
     'default', 'none', 'slight', 'medium', 'full'
-);
-enum 'Graphics::Primitive::Font::Slants' => (
+];
+enum 'Graphics::Primitive::Font::Slants' => [
     'normal', 'italic', 'oblique'
-);
-enum 'Graphics::Primitive::Font::SubpixelOrders' => (
+];
+enum 'Graphics::Primitive::Font::SubpixelOrders' => [
     qw(default rgb bgr vrgb vbgr)
-);
-enum 'Graphics::Primitive::Font::Variants' => (
+];
+enum 'Graphics::Primitive::Font::Variants' => [
     'normal', 'small-caps'
-);
-enum 'Graphics::Primitive::Font::Weights' => (
+];
+enum 'Graphics::Primitive::Font::Weights' => [
     'normal', 'bold'
-);
+];
 
 has 'antialias_mode' => (
     is => 'rw',

--- a/lib/Graphics/Primitive/Oriented.pm
+++ b/lib/Graphics/Primitive/Oriented.pm
@@ -3,7 +3,7 @@ use Moose::Role;
 
 use Moose::Util::TypeConstraints;
 
-enum 'Graphics::Primitive::Orientations' => qw(vertical horizontal);
+enum 'Graphics::Primitive::Orientations' => [qw(vertical horizontal)];
 
 has 'orientation' => (
     is => 'rw',

--- a/lib/Graphics/Primitive/TextBox.pm
+++ b/lib/Graphics/Primitive/TextBox.pm
@@ -3,13 +3,13 @@ use Moose;
 use MooseX::Storage;
 use Moose::Util::TypeConstraints;
 
-# enum 'Graphics::Primitive::TextBox::Directions' => (
+# enum 'Graphics::Primitive::TextBox::Directions' => [(
 #     'auto', 'ltr', 'rtl'
-# );
+# )];
 # enum 'Graphics::Primitive::TextBox::WrapModes'
-#     => qw(word char word_char);
+#     => [qw(word char word_char)];
 # enum 'Graphics::Primitive::TextBox::EllipsizeModes'
-#     => qw(none start middle end);
+#     => [qw(none start middle end)];
 
 extends 'Graphics::Primitive::Component';
 


### PR DESCRIPTION
This fixes RT#90658: warnings produced by the change to the way enum should be called.

See https://rt.cpan.org/Ticket/Display.html?id=90658
