### PR TITLE
Change the default font for Windows

### DIFF
--- a/lib/Graphics/Primitive/Font.pm
+++ b/lib/Graphics/Primitive/Font.pm
@@ -36,7 +36,7 @@ has 'antialias_mode' => (
 has 'family' => (
     is => 'rw',
     isa => 'Str',
-    default => 'Sans'
+    default => $ENV{GRAPHICS_PRIMITIVE_DEFAULT_FONT} || ($^O eq 'MSWin32'?'Arial':'Sans')
 );
 has 'hint_metrics' => (
     is => 'rw',


### PR DESCRIPTION
Chart::Clicker currently fails to compile on Windows, as the Sans font doesn't exist.  The Chart::Clicker tests add text labels, which use Graphics::Primitive::Font and Graphics::Primitive::Driver::GD to work out the size of the text label bounding box.  This is undefined because the Sans font doesn't exist, so all the tests fail.  This change also reads the GRAPHICS_PRIMITIVE_DEFAULT_FONT environment variable to allow the default font to be overridden.