### PR TITLE
MooseX::Storage switched from JSON::Any to JSON::MaybeXS since 0.48

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,9 +10,9 @@ requires 'Geometry::Primitive' => '0.16';
 requires 'Graphics::Color' => '0.20';
 requires 'Moose' => '0.90';
 requires 'MooseX::Clone' => '0.04';
-requires 'MooseX::Storage' => '0.17';
+requires 'MooseX::Storage' => '0.48';
 requires 'Forest' => '0.06';
-requires 'JSON::Any' => '1.22';
+requires 'JSON::MaybeXS' => '1.001000';
 requires 'Data::Visitor::Callback' => '0.30';
 
 repository 'git://github.com/gphat/graphics-primitive.git';


### PR DESCRIPTION
See 
https://metacpan.org/source/ETHER/MooseX-Storage-0.52/Changes#L19
https://metacpan.org/source/ETHER/MooseX-Storage-0.52/META.yml#L62

This should also fix https://rt.cpan.org/Public/Bug/Display.html?id=102461