### PR TITLE
fix an example code in SYNOPSIS of Graphics::Primitive

### DIFF
--- a/lib/Graphics/Primitive.pm
+++ b/lib/Graphics/Primitive.pm
@@ -26,7 +26,10 @@ and the like.
           red => 1, green => 0, blue => 0
       ),
       width => 500, height => 350,
-      border => new Graphics::Primitive::Border->new( width => 5 )
+      border => Graphics::Primitive::Border->new(
+        width => 5,
+        color => Graphics::Color::RGB->new(red => 0, green => 0, blue => 1)
+      )
     );
 
     my $driver = Graphics::Primitive::Driver::Cairo->new(format => 'SVG');


### PR DESCRIPTION
Present example code in that place is broken: 

- there are now 2 "new" in the line
- without specifying "color", you get an error `Can't call method "as_array_with_alpha" on an undefined value at .../Graphics/Primitive/Driver/Cairo.pm line 301`